### PR TITLE
Deal with non-redirect responses

### DIFF
--- a/function.js
+++ b/function.js
@@ -21,6 +21,17 @@ module.exports = (context, req) => {
   const dropboxUrlRawPath = [dropboxUrlPathParts[1], 'raw', dropboxUrlPathParts[2], dropboxUrlPathParts[3]].join('/');
 
   https.get(`https://${dropboxUrl.hostname}/${dropboxUrlRawPath}`, result => {
+    if (result.statusCode !== 302) {
+      context.res = {
+        body: {
+          error: result.statusMessage
+        },
+        status: result.statusCode
+      };
+      context.done();
+      return;
+    }
+
     let headers = {};
 
     headers['location'] = result.headers['location'];
@@ -30,7 +41,7 @@ module.exports = (context, req) => {
     context.res = {
       body: null,
       headers: headers,
-      status: 302
+      status: result.statusCode
     };
     context.done();
   });


### PR DESCRIPTION
If the request to Dropbox returns a non-redirect (eg 404), pass
that status code through to the requestor, instead of a redirect,
which will generally be missing the `Location` header.